### PR TITLE
CI: Build ABI for clippy

### DIFF
--- a/.github/workflows/ipc.yaml
+++ b/.github/workflows/ipc.yaml
@@ -69,5 +69,15 @@ jobs:
           cache-prefix: ipc-${{ matrix.make.name }}-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
           cache-suffix: ${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Cache Solidity ABI arfiacts
+        uses: actions/cache@v2
+        with:
+          path: ./contracts/out
+          key: contracts-abi-${{ hashFiles('./contracts/src/**/*.sol') }}
+
+      - name: Generate Solidity ABI artifacts
+        run: >-
+          [ -d contracts/out ] || cd contracts && make compile-abi
+
       - name: ${{ matrix.make.name }}
         run: cd ipc && make ${{ matrix.make.task }}

--- a/.github/workflows/ipld-resolver.yaml
+++ b/.github/workflows/ipld-resolver.yaml
@@ -68,5 +68,15 @@ jobs:
           cache-prefix: ipld-resolver-${{ matrix.make.name }}-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('rust-toolchain', 'rust-toolchain.toml') }}
           cache-suffix: ${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Cache Solidity ABI arfiacts
+        uses: actions/cache@v2
+        with:
+          path: ./contracts/out
+          key: contracts-abi-${{ hashFiles('./contracts/src/**/*.sol') }}
+
+      - name: Generate Solidity ABI artifacts
+        run: >-
+          [ -d contracts/out ] || cd contracts && make compile-abi
+
       - name: ${{ matrix.make.name }}
         run: cd ipld-resolver && make ${{ matrix.make.task }}

--- a/fendermint/Makefile
+++ b/fendermint/Makefile
@@ -55,7 +55,7 @@ check-fmt:
 	@# `nightly` is required to support ignore list in rustfmt.toml
 	cargo +nightly fmt --all --check
 
-check-clippy:
+check-clippy: $(IPC_ACTORS_GEN)
 	cargo clippy --all --tests -- -D clippy::all
 
 docker-deps: $(BUILTIN_ACTORS_BUNDLE) $(IPC_ACTORS_OUT) $(IPC_ACTORS_GEN)

--- a/fendermint/Makefile
+++ b/fendermint/Makefile
@@ -6,7 +6,7 @@ BUILTIN_ACTORS_BUNDLE := $(PWD)/builtin-actors/output/bundle.car
 IPC_ACTORS_DIR        := $(PWD)/../contracts
 IPC_ACTORS_OUT        := $(IPC_ACTORS_DIR)/out
 IPC_ACTORS_CODE       := $(shell find $(IPC_ACTORS_DIR) -type f \( -name "*.sol" \))
-IPC_ACTORS_GEN				:= .contracts-gen
+IPC_ACTORS_GEN        := .contracts-gen
 
 FENDERMINT_CODE       := $(shell find . -type f \( -name "*.rs" -o -name "Cargo.toml" \) | grep -v target)
 
@@ -89,6 +89,8 @@ docker-build: docker-deps $(FENDERMINT_CODE)
 # which means we are not tied to the release cycle of both FVM _and_ actors;
 # so long as they work together.
 actor-bundle: $(BUILTIN_ACTORS_BUNDLE)
+
+compile-abi: $(IPC_ACTORS_GEN)
 
 # Download a released builtin-actors bundle CAR file.
 $(BUILTIN_ACTORS_BUNDLE):

--- a/ipc/Makefile
+++ b/ipc/Makefile
@@ -1,17 +1,20 @@
 .PHONY: all build test lint license check-fmt check-clippy diagrams install-infra clean-infra
 
+IPC_ACTORS_DIR := $(PWD)/../contracts
+IPC_ACTORS_OUT := $(IPC_ACTORS_DIR)/out
+
 all: test build
 
-build:
+build: $(IPC_ACTORS_OUT)
 	cargo build --release -p ipc-cli && mkdir -p bin/ && cp target/release/ipc-cli ./bin/ipc-cli
 
-test:
+test: $(IPC_ACTORS_OUT)
 	cargo test --release --package 'ipc-*'
 
-itest:
+itest: $(IPC_ACTORS_OUT)
 	cargo test -p itest --test checkpoint -- --nocapture
 
-e2e:
+e2e: $(IPC_ACTORS_OUT)
 	cargo test --release -p ipc_e2e
 
 clean:
@@ -31,7 +34,7 @@ check-fmt:
 	@# `nightly` is required to support ignore list in rustfmt.toml
 	cargo +nightly fmt --all --check
 
-check-clippy:
+check-clippy: $(IPC_ACTORS_OUT)
 	cargo clippy --all --tests -- -D clippy::all
 
 diagrams:
@@ -42,3 +45,7 @@ check-diagrams: diagrams
 		echo "There are uncommitted changes to the diagrams"; \
 		exit 1; \
 	fi
+
+# Regenerate the ABI artifacts if we don't have them already, or they changed.
+$(IPC_ACTORS_OUT):
+	cd $(IPC_ACTORS_DIR) && make compile-abi

--- a/ipc/Makefile
+++ b/ipc/Makefile
@@ -1,20 +1,17 @@
 .PHONY: all build test lint license check-fmt check-clippy diagrams install-infra clean-infra
 
-IPC_ACTORS_DIR := $(PWD)/../contracts
-IPC_ACTORS_OUT := $(IPC_ACTORS_DIR)/out
-
 all: test build
 
-build: $(IPC_ACTORS_OUT)
+build:
 	cargo build --release -p ipc-cli && mkdir -p bin/ && cp target/release/ipc-cli ./bin/ipc-cli
 
-test: $(IPC_ACTORS_OUT)
+test:
 	cargo test --release --package 'ipc-*'
 
-itest: $(IPC_ACTORS_OUT)
+itest:
 	cargo test -p itest --test checkpoint -- --nocapture
 
-e2e: $(IPC_ACTORS_OUT)
+e2e:
 	cargo test --release -p ipc_e2e
 
 clean:
@@ -34,7 +31,7 @@ check-fmt:
 	@# `nightly` is required to support ignore list in rustfmt.toml
 	cargo +nightly fmt --all --check
 
-check-clippy: $(IPC_ACTORS_OUT)
+check-clippy:
 	cargo clippy --all --tests -- -D clippy::all
 
 diagrams:
@@ -45,7 +42,3 @@ check-diagrams: diagrams
 		echo "There are uncommitted changes to the diagrams"; \
 		exit 1; \
 	fi
-
-# Regenerate the ABI artifacts if we don't have them already, or they changed.
-$(IPC_ACTORS_OUT):
-	cd $(IPC_ACTORS_DIR) && make compile-abi


### PR DESCRIPTION
Builds the ABI JSON for more `check-clippy` and `ipc` in general.