### PR TITLE
Fund with token

### DIFF
--- a/fendermint/fendermint/vm/actor_interface/src/ipc.rs
+++ b/fendermint/fendermint/vm/actor_interface/src/ipc.rs
@@ -64,6 +64,10 @@ lazy_static! {
                             name: "GatewayMessengerFacet",
                             abi: ia::gateway_messenger_facet::GATEWAYMESSENGERFACET_ABI.to_owned(),
                         },
+                        EthFacet {
+                            name: "XnetMessagingFacet",
+                            abi: ia::xnet_messaging_facet::XNETMESSAGINGFACET_ABI.to_owned(),
+                        },
                     ],
                 },
             ),

--- a/fendermint/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -282,7 +282,6 @@ where
                 let facets = deployer
                     .facets(ipc::gateway::CONTRACT_NAME)
                     .context("failed to collect gateway facets")?;
-                tracing::info!(?facets, "deploying ipc gateway with facets");
 
                 deployer.deploy_contract(
                     &mut state,

--- a/fendermint/fendermint/vm/interpreter/src/fvm/genesis.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/genesis.rs
@@ -282,6 +282,7 @@ where
                 let facets = deployer
                     .facets(ipc::gateway::CONTRACT_NAME)
                     .context("failed to collect gateway facets")?;
+                tracing::info!(?facets, "deploying ipc gateway with facets");
 
                 deployer.deploy_contract(
                     &mut state,

--- a/fendermint/fendermint/vm/interpreter/src/fvm/topdown.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/topdown.rs
@@ -49,14 +49,17 @@ where
     DB: Blockstore + Sync + Send + 'static,
 {
     let minted_tokens = tokens_to_mint(&messages);
+    tracing::debug!(token = minted_tokens.to_string(), "tokens to mint in child");
 
-    gateway_caller
-        .mint_to_gateway(state, minted_tokens.clone())
-        .context("failed to mint to gateway")?;
+    if !minted_tokens.is_zero() {
+        gateway_caller
+            .mint_to_gateway(state, minted_tokens.clone())
+            .context("failed to mint to gateway")?;
 
-    state.update_circ_supply(|circ_supply| {
-        *circ_supply += minted_tokens;
-    });
+        state.update_circ_supply(|circ_supply| {
+            *circ_supply += minted_tokens;
+        });
+    }
 
     gateway_caller.apply_cross_messages(state, messages)
 }

--- a/ipc/ipc/cli/src/commands/crossmsg/mod.rs
+++ b/ipc/ipc/cli/src/commands/crossmsg/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
-use self::fund::{PreFund, PreFundArgs};
+use self::fund::{PreFund, PreFundArgs, FundWithToken, FundWithTokenArgs};
 use self::release::{PreRelease, PreReleaseArgs};
 use self::topdown_cross::{
     LatestParentFinality, LatestParentFinalityArgs, ListTopdownMsgs, ListTopdownMsgsArgs,
@@ -32,6 +32,7 @@ impl CrossMsgsCommandsArgs {
     pub async fn handle(&self, global: &GlobalArguments) -> anyhow::Result<()> {
         match &self.command {
             Commands::Fund(args) => Fund::handle(global, args).await,
+            Commands::FundWithToken(args) => FundWithToken::handle(global, args).await,
             Commands::PreFund(args) => PreFund::handle(global, args).await,
             Commands::Release(args) => Release::handle(global, args).await,
             Commands::PreRelease(args) => PreRelease::handle(global, args).await,
@@ -45,6 +46,7 @@ impl CrossMsgsCommandsArgs {
 #[derive(Debug, Subcommand)]
 pub(crate) enum Commands {
     Fund(FundArgs),
+    FundWithToken(FundWithTokenArgs),
     PreFund(PreFundArgs),
     Release(ReleaseArgs),
     PreRelease(PreReleaseArgs),

--- a/ipc/ipc/cli/src/commands/crossmsg/mod.rs
+++ b/ipc/ipc/cli/src/commands/crossmsg/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
-use self::fund::{PreFund, PreFundArgs, FundWithToken, FundWithTokenArgs};
+use self::fund::{FundWithToken, FundWithTokenArgs, PreFund, PreFundArgs};
 use self::release::{PreRelease, PreReleaseArgs};
 use self::topdown_cross::{
     LatestParentFinality, LatestParentFinalityArgs, ListTopdownMsgs, ListTopdownMsgsArgs,

--- a/ipc/ipc/provider/src/lib.rs
+++ b/ipc/ipc/provider/src/lib.rs
@@ -479,6 +479,30 @@ impl IpcProvider {
             .await
     }
 
+    /// Funds an account in a child subnet with erc20 token, provided that the supply source kind is
+    /// `ERC20`. If `from` is None, it will use the default address config in `ipc.toml`.
+    /// If `to` is `None`, the `from` account will be funded.
+    pub async fn fund_with_token(
+        &mut self,
+        subnet: SubnetID,
+        from: Option<Address>,
+        to: Option<Address>,
+        amount: TokenAmount,
+    ) -> anyhow::Result<ChainEpoch> {
+        let parent = subnet.parent().ok_or_else(|| anyhow!("no parent found"))?;
+        let conn = match self.connection(&parent) {
+            None => return Err(anyhow!("target parent subnet not found")),
+            Some(conn) => conn,
+        };
+
+        let subnet_config = conn.subnet();
+        let sender = self.check_sender(subnet_config, from)?;
+
+        conn.manager()
+            .fund_with_token(subnet, sender, to.unwrap_or(sender), amount)
+            .await
+    }
+
     /// Release to an account in a child subnet, if `to` is `None`, the self account
     /// is funded.
     pub async fn release(

--- a/ipc/ipc/provider/src/manager/subnet.rs
+++ b/ipc/ipc/provider/src/manager/subnet.rs
@@ -88,6 +88,25 @@ pub trait SubnetManager: Send + Sync + TopDownFinalityQuery + BottomUpCheckpoint
         amount: TokenAmount,
     ) -> Result<ChainEpoch>;
 
+    /// Sends funds to a specified subnet receiver using ERC20 tokens.
+    /// This function locks the amount of ERC20 tokens into custody and then mints the supply in the specified subnet.
+    /// It checks if the subnet's supply strategy is ERC20 and if not, the operation is reverted.
+    /// It allows for free injection of funds into a subnet and is protected against reentrancy.
+    ///
+    /// # Arguments
+    ///
+    /// * `subnetId` - The ID of the subnet where the funds will be sent to.
+    /// * `from`     - The funding address.
+    /// * `to`       - The funded address.
+    /// * `amount`   - The amount of ERC20 tokens to be sent.
+    async fn fund_with_token(
+        &self,
+        subnet: SubnetID,
+        from: Address,
+        to: Address,
+        amount: TokenAmount,
+    ) -> Result<ChainEpoch>;
+
     /// Release creates a new check message to release funds in parent chain
     /// Returns the epoch that the released is executed in the child.
     async fn release(


### PR DESCRIPTION
Implement `fund_with_token` api for erc20 token transfers, see [here](https://github.com/consensus-shipyard/ipc-monorepo/blob/0bae28b402a9bfef072e70048480d22e8d70e59c/contracts/src/gateway/GatewayManagerFacet.sol#L178C14-L178C27). 