### PR TITLE
IPC-506: Fix GetCode and GetStorageAt for ethaccount

### DIFF
--- a/fendermint/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/fendermint/eth/api/examples/ethers.rs
@@ -601,18 +601,23 @@ where
     // We could calculate the storage location of the balance of the owner of the contract,
     // but let's just see what it returns with at slot 0. See an example at
     // https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat
+    let storage_location = {
+        let mut bz = [0u8; 32];
+        U256::zero().to_big_endian(&mut bz);
+        H256::from_slice(&bz)
+    };
+
     request(
         "eth_getStorageAt",
-        mw.get_storage_at(
-            contract.address(),
-            {
-                let mut bz = [0u8; 32];
-                U256::zero().to_big_endian(&mut bz);
-                H256::from_slice(&bz)
-            },
-            None,
-        )
-        .await,
+        mw.get_storage_at(contract.address(), storage_location, None)
+            .await,
+        |_| true,
+    )?;
+
+    request(
+        "eth_getStorageAt /w account",
+        mw.get_storage_at(from.eth_addr, storage_location, None)
+            .await,
         |_| true,
     )?;
 

--- a/fendermint/fendermint/eth/api/examples/ethers.rs
+++ b/fendermint/fendermint/eth/api/examples/ethers.rs
@@ -617,9 +617,15 @@ where
     )?;
 
     request(
-        "eth_code",
+        "eth_getCode",
         mw.get_code(contract.address(), None).await,
         |bz| *bz == deployed_bytecode,
+    )?;
+
+    request(
+        "eth_getCode /w account",
+        mw.get_code(from.eth_addr, None).await,
+        |bz| bz.is_empty(),
     )?;
 
     request("eth_syncing", mw.syncing().await, |s| {


### PR DESCRIPTION
Fixes #506 

This is an alternative for #507 that makes 22 exit code work like a `PLACEHOLDER` account by returning `None` from `read_evm_actor`.

I think it's sufficient indication that we're dealing with `ETHACCOUNT`, because:
* `read_evm_actor` is an internal method to the Ethereum API facade, it's only ever called with `H160` addresses and two well known method numbers (`GetCode` and `GetStorageAt`), never with user input
* therefore the `Message` will go to an `f410` address constructed from the 20 byte address hash, and if that exists, it's some sort of Ethereum account or contract (if it didn't exist we wouldn't get code 22)
* if the actor doesn't handle the two well known method numbers, it's not an EVM actor