### PR TITLE
FIX: New lints with Rust 1.75

### DIFF
--- a/fendermint/docker/builder.ci.Dockerfile
+++ b/fendermint/docker/builder.ci.Dockerfile
@@ -46,7 +46,7 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
 WORKDIR /app
 
 # Update the version here if our `rust-toolchain.toml` would cause something new to be fetched every time.
-ARG RUST_VERSION=1.73
+ARG RUST_VERSION=1.75
 RUN rustup install ${RUST_VERSION} && rustup target add wasm32-unknown-unknown
 
 # Defined here so anything above it can be cached as a common dependency.

--- a/fendermint/fendermint/testing/src/arb/address.rs
+++ b/fendermint/fendermint/testing/src/arb/address.rs
@@ -3,9 +3,6 @@
 use fvm_shared::address::Address;
 use quickcheck::{Arbitrary, Gen};
 
-pub use crate::arb::cid::ArbCid;
-pub use crate::arb::subnetid::ArbSubnetID;
-
 /// Unfortunately an arbitrary `DelegatedAddress` can be inconsistent with bytes that do not correspond to its length.
 #[derive(Clone, Debug)]
 pub struct ArbAddress(pub Address);

--- a/fendermint/fendermint/vm/interpreter/src/fvm/state/ipc.rs
+++ b/fendermint/fendermint/vm/interpreter/src/fvm/state/ipc.rs
@@ -224,7 +224,7 @@ impl<DB: Blockstore> GatewayCaller<DB> {
         Ok(if !has_committed {
             None
         } else {
-            Some(IPCParentFinality::try_from(prev_finality)?)
+            Some(IPCParentFinality::from(prev_finality))
         })
     }
 
@@ -283,7 +283,7 @@ impl<DB: Blockstore> GatewayCaller<DB> {
         let r = self
             .getter
             .call(state, |c| c.get_latest_parent_finality())?;
-        Ok(IPCParentFinality::try_from(r)?)
+        Ok(IPCParentFinality::from(r))
     }
 
     /// Get the Ethereum adresses of validators who signed a checkpoint.

--- a/fendermint/fendermint/vm/topdown/src/finality/mod.rs
+++ b/fendermint/fendermint/vm/topdown/src/finality/mod.rs
@@ -11,7 +11,6 @@ use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::staking::StakingChangeRequest;
 
 pub use fetch::CachedFinalityProvider;
-pub use null::FinalityWithNull;
 
 pub(crate) type ParentViewPayload = (BlockHash, Vec<StakingChangeRequest>, Vec<CrossMsg>);
 

--- a/fendermint/fendermint/vm/topdown/src/finality/null.rs
+++ b/fendermint/fendermint/vm/topdown/src/finality/null.rs
@@ -349,7 +349,8 @@ impl FinalityWithNull {
 
 #[cfg(test)]
 mod tests {
-    use crate::finality::{FinalityWithNull, ParentViewPayload};
+    use super::FinalityWithNull;
+    use crate::finality::ParentViewPayload;
     use crate::{BlockHeight, Config, IPCParentFinality};
     use async_stm::{atomically, atomically_or_err};
 

--- a/fvm-utils/primitives/src/uints.rs
+++ b/fvm-utils/primitives/src/uints.rs
@@ -4,9 +4,6 @@
 // see https://github.com/paritytech/parity-common/issues/660
 #![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern)]
 
-#[doc(inline)]
-pub use uint::byteorder;
-
 use serde::{Deserialize, Serialize};
 //use substrate_bn::arith;
 

--- a/ipc/ipc/provider/src/lib.rs
+++ b/ipc/ipc/provider/src/lib.rs
@@ -833,8 +833,7 @@ impl IpcProvider {
             key_type,
             base64::engine::general_purpose::STANDARD.decode(&keyinfo.private_key)?,
         ));
-        let key_info = ipc_identity::KeyInfo::try_from(key_info)
-            .map_err(|_| anyhow!("couldn't get fvm key info from string"))?;
+        let key_info = ipc_identity::KeyInfo::from(key_info);
         Ok(wallet.import(key_info)?)
     }
 


### PR DESCRIPTION
Fixes some new warnings caught after Rust 1.75 became stable.

(Locally I didn't pick them until I ran `rustup update stable`).