### PR TITLE
FIX: Make sure check errors propagate to JSON-RPC

### DIFF
--- a/fendermint/fendermint/eth/api/src/apis/eth.rs
+++ b/fendermint/fendermint/eth/api/src/apis/eth.rs
@@ -618,8 +618,9 @@ where
         // Ok(et::TxHash::from_slice(res.hash.as_bytes()))
         Ok(msghash)
     } else {
-        error(
+        error_with_data(
             ExitCode::new(res.code.value()),
+            res.log,
             hex::encode(res.data.as_ref()), // TODO: What is the content?
         )
     }


### PR DESCRIPTION
Related to #506 

Changes `to_check_tx` to put the error message into `CheckTx::log` instead of `CheckTx::info`, and also fixes `eth::send_raw_transaction` to use `error_with_data` and to make sure the error message propagates through the JSON-RPC pipeline:

```console
$ make deploy-local-ipc
...
Error: 
(code: 2, message: expected sequence 1, got 2, data: Some(String("")))
```